### PR TITLE
Make controller cross-origin to avoid CORS problems if called from an…

### DIFF
--- a/src/main/java/com/nurkiewicz/jsonstreaming/StreamingController.java
+++ b/src/main/java/com/nurkiewicz/jsonstreaming/StreamingController.java
@@ -1,5 +1,6 @@
 package com.nurkiewicz.jsonstreaming;
 
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,7 @@ import java.time.Instant;
 import static org.springframework.http.MediaType.APPLICATION_NDJSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 
+@CrossOrigin()
 @RestController
 public class StreamingController {
 


### PR DESCRIPTION
…other service.

I have created a demonstration of using ndjson in react-query based upon your fine backend. Its available here:

https://github.com/alex-jesper/react-query-ndjson

The calls to your backend fails since cors is disallowed. Your use is curl where cors is not considered so your solution is not broken. This will just allow calls from an application.

You might not want to include this as it is not really required for your use-case. That is fine, your choice :)